### PR TITLE
Fall back to default font if Libertinus is unavailable

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2018-10-02  Ista Zahn  <istazahn@gmail.com>
+
+        * inst/iqssDemo/beamerfontthemeiqss.sty: Fall back to default font
+	if Libertinus is unavailable
+
+	* inst/rmarkdown/templates/iqss/skeleton/beamerfontthemeiqss.sty:
+	Ditto
+
 2018-09-27  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Release 0.0.2

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ These themes use additional (free) fonts you may need to install:
 
 - [Metropolis](https://github.com/matze/mtheme) wants [Fira Sans](https://github.com/mozilla/Fira)
   but can proceed with alternate fonts;
-- [IQSS Beamer Theme](https://github.com/IQSS/iqss-beamer-theme) really requires
+- [IQSS Beamer Theme](https://github.com/IQSS/iqss-beamer-theme) wants
   [Libertinus](https://github.com/libertinus-fonts/libertinus), see the
   [IQSS Beamer Theme](https://github.com/IQSS/iqss-beamer-theme)  page for details.
 - [Presento Theme](https://github.com/RatulSaha/presento) wants 

--- a/inst/iqssDemo/beamerfontthemeiqss.sty
+++ b/inst/iqssDemo/beamerfontthemeiqss.sty
@@ -1,7 +1,48 @@
 \usefonttheme{professionalfonts}
+
 \RequirePackage{fontspec}
 
-\setmainfont{Libertinus Serif}
-\setsansfont{Libertinus Sans}
-\setmathfont{Libertinus Math}
-\setmonofont{Libertinus Mono}
+%% checkfont and iffontsavaiable copied from the metropolis theme
+%% by Matthias Vo­gelge­sang.
+%    Checks if a font is installed; if not, |fontsnotfound| is increased.
+\newcounter{fontsnotfound}
+\newcommand{\checkfont}[1]{%
+  \suppressfontnotfounderror=1%
+  \font\x = "#1" at 10pt
+  \selectfont
+  \ifx\x\nullfont%
+  \stepcounter{fontsnotfound}%
+  \fi%
+  \suppressfontnotfounderror=0%
+}
+%   Resets the |fontsnotfound| counter and calls |\checkfont| for each font in
+%   the comma separated list in the first argument.
+\newcommand{\iffontsavailable}[3]{%
+  \setcounter{fontsnotfound}{0}%
+  \expandafter\forcsvlist\expandafter%
+  \checkfont\expandafter{#1}%
+  \ifnum\value{fontsnotfound}=0%
+  #2%
+  \else%
+  #3%
+  \fi%
+}
+
+\iffontsavailable{Libertinus Serif,%
+  Libertinus Sans,%
+  LibertinusMath,%
+  Libertinus Mono}%
+{%
+  \setmainfont{Libertinus Serif}
+  \setsansfont{Libertinus Sans}
+  \setmathfont{Libertinus Math}
+  \setmonofont{Libertinus Mono}
+}{%
+  \PackageWarning{beamerthememeiqss}{%
+    Could not find Libertinus fonts.
+    Please install them from
+    https://github.com/libertinus-fonts/libertinus/releases
+    following the instructions at
+    https://github.com/IQSS/iqss-beamer-theme/blob/master/README.md% 
+  }
+}

--- a/inst/rmarkdown/templates/iqss/skeleton/beamerfontthemeiqss.sty
+++ b/inst/rmarkdown/templates/iqss/skeleton/beamerfontthemeiqss.sty
@@ -1,7 +1,48 @@
 \usefonttheme{professionalfonts}
+
 \RequirePackage{fontspec}
 
-\setmainfont{Libertinus Serif}
-\setsansfont{Libertinus Sans}
-\setmathfont{Libertinus Math}
-\setmonofont{Libertinus Mono}
+%% checkfont and iffontsavaiable copied from the metropolis theme
+%% by Matthias Vo­gelge­sang.
+%    Checks if a font is installed; if not, |fontsnotfound| is increased.
+\newcounter{fontsnotfound}
+\newcommand{\checkfont}[1]{%
+  \suppressfontnotfounderror=1%
+  \font\x = "#1" at 10pt
+  \selectfont
+  \ifx\x\nullfont%
+  \stepcounter{fontsnotfound}%
+  \fi%
+  \suppressfontnotfounderror=0%
+}
+%   Resets the |fontsnotfound| counter and calls |\checkfont| for each font in
+%   the comma separated list in the first argument.
+\newcommand{\iffontsavailable}[3]{%
+  \setcounter{fontsnotfound}{0}%
+  \expandafter\forcsvlist\expandafter%
+  \checkfont\expandafter{#1}%
+  \ifnum\value{fontsnotfound}=0%
+  #2%
+  \else%
+  #3%
+  \fi%
+}
+
+\iffontsavailable{Libertinus Serif,%
+  Libertinus Sans,%
+  LibertinusMath,%
+  Libertinus Mono}%
+{%
+  \setmainfont{Libertinus Serif}
+  \setsansfont{Libertinus Sans}
+  \setmathfont{Libertinus Math}
+  \setmonofont{Libertinus Mono}
+}{%
+  \PackageWarning{beamerthememeiqss}{%
+    Could not find Libertinus fonts.
+    Please install them from
+    https://github.com/libertinus-fonts/libertinus/releases
+    following the instructions at
+    https://github.com/IQSS/iqss-beamer-theme/blob/master/README.md% 
+  }
+}


### PR DESCRIPTION
I had a hard time deciding whether to throw a warning or an error if the preferred font is unavailable. When using `rmarkdown::render()` there doesn't seem to be a way to continue past `xelatex` errors, so the only improvement for rmarkdown users would be a more informative error that instructs them to install the fonts. I went with a warning for now, but unfortunately `rmarkdown::render()` doesn't even display warnings, so many users will probably never get the message.

For now I'm throwing a warning and relying on the README to inform users that they should install the Libertinus font. Feedback welcome!