### PR TITLE
provide better defaults for colortheme and two fontsizes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,10 @@
 2018-10-09  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Rolled minor version 
+	* DESCRIPTION (Version, Date): Rolled minor version
+
+	* inst/rmarkdown/templates/monash/resources/template.tex: Provide
+	better fallbacks for fontsize, titlefontsize, colortheme
+	* inst/rmarkdown/templates/monash/skeleton/skeleton.Rmd: Idem
 
 2018-10-09  Rob Hyndman  <rob.hyndman@monash.edu>
 

--- a/inst/rmarkdown/templates/monash/resources/template.tex
+++ b/inst/rmarkdown/templates/monash/resources/template.tex
@@ -1,6 +1,6 @@
 \PassOptionsToPackage{unicode=true}{hyperref} % options for packages loaded elsewhere
 \PassOptionsToPackage{hyphens}{url}
-\documentclass[$if(fontsize)$$fontsize$,$endif$$if(lang)$$babel-lang$,$endif$$if(handout)$handout,$endif$$if(colorlinks)$dvipsnames,$endif$$if(beamer)$ignorenonframetext,$endif$$for(classoption)$$classoption$$sep$,$endfor$]{$documentclass$}
+\documentclass[$if(fontsize)$$fontsize$,$else$14pt,$endif$$if(lang)$$babel-lang$,$endif$$if(handout)$handout,$endif$$if(colorlinks)$dvipsnames,$endif$$if(beamer)$ignorenonframetext,$endif$$for(classoption)$$classoption$$sep$,$endfor$]{$documentclass$}
 \setbeamertemplate{caption}[numbered]
 \setbeamertemplate{caption label separator}{: }
 \setbeamercolor{caption name}{fg=normal text.fg}
@@ -63,6 +63,8 @@ $endif$
 
 $if(colortheme)$
   \usecolortheme{$colortheme$}
+$else$
+  \usecolortheme{monashwhite}
 $endif$
 
 $if(fonttheme)$
@@ -71,6 +73,8 @@ $endif$
 
 $if(titlefontsize)$
   \setbeamerfont{title}{series=\bfseries,parent=structure,size=\fontsize{$titlefontsize$}{32}}
+$else$
+  \setbeamerfont{title}{series=\bfseries,parent=structure,size=\fontsize{22pt}{32}}
 $endif$
 
 $if(mainfont)$

--- a/inst/rmarkdown/templates/monash/resources/template.tex
+++ b/inst/rmarkdown/templates/monash/resources/template.tex
@@ -63,18 +63,15 @@ $endif$
 
 $if(colortheme)$
   \usecolortheme{$colortheme$}
-$else$
-  \usecolortheme{monashwhite}
 $endif$
 
 $if(fonttheme)$
   \usefonttheme{$fonttheme$}
 $endif$
 
+% A default size of 24 is set in beamerthememonash.sty
 $if(titlefontsize)$
   \setbeamerfont{title}{series=\bfseries,parent=structure,size=\fontsize{$titlefontsize$}{32}}
-$else$
-  \setbeamerfont{title}{series=\bfseries,parent=structure,size=\fontsize{22pt}{32}}
 $endif$
 
 $if(mainfont)$

--- a/inst/rmarkdown/templates/monash/skeleton/beamerthememonash.sty
+++ b/inst/rmarkdown/templates/monash/skeleton/beamerthememonash.sty
@@ -3,7 +3,8 @@
 %% Updated by Rob J Hyndman. 8 October 2018
 
 \RequirePackage{beamerthememetropolis}
-\usecolortheme{monashblue}
+% For binb, one can alter the color theme by by setting eg 'colortheme: monashblue' in the YAML header
+\usecolortheme{monashwhite}
 \usefonttheme{monash}
 
 \metroset{progressbar=foot}
@@ -55,6 +56,7 @@
 \def\placefig#1#2#3#4{\begin{textblock}{.1}(#1,#2)\rlap{\includegraphics[#3]{#4}}\end{textblock}}
 
 % Monash title page
+% For binb, one can alter the font size by setting eg 'titlefontsize: 20pt' in the YAML header
 \setbeamerfont{title}{series=\bfseries,parent=structure,size=\fontsize{24}{32}}
 \setbeamertemplate{title page}
 {\placefig{-0.01}{-0.01}{width=1.01\paperwidth,height=1.01\paperheight}{titlepage}

--- a/inst/rmarkdown/templates/monash/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/monash/skeleton/skeleton.Rmd
@@ -2,10 +2,7 @@
 title: Monash Beamer Class Demonstration
 author: Rob J Hyndman
 date: \today
-fontsize: 14pt
-titlefontsize: 22pt
 classoption: compress
-colortheme: monashblue
 toc: true
 output: binb::monash
 ---


### PR DESCRIPTION
This improves (or so I hope) three different YAML header values:
- the colour theme become `monashwhite` unless overridden
- the default fontsize is 14pt unless overridden (same code as in Presento)
- the default titlefontsize is 22pt as before (and can be overriden)
which shortens the YAML header.

I guess `toc` and `compress` can/should stay.  Defaults for these two are less obvious.

Thumbs up or down, @robjhyndman and @izahn ?