### PR TITLE
add iqss header option

### DIFF
--- a/inst/rmarkdown/templates/iqss/resources/template.tex
+++ b/inst/rmarkdown/templates/iqss/resources/template.tex
@@ -284,6 +284,10 @@ $if(subtitle)$
   \subtitle{$subtitle$}
 $endif$
 
+$if(titlegraphic)$
+  \titlegraphic{\includegraphics{$titlegraphic$}}
+$endif$
+
 $if(author)$
   \author[
     $if(short-author)$


### PR DESCRIPTION
This allows the header graphic to be set in the YAML header. It makes the theme usable outside IQSS / Harvard, though the default is still to use the IQSS header graphic.

I'm not really sure I've done this in the best way. In particular, I'd like to have a way of using no header graphic. Suggestions welcome.