### PR TITLE
presento read from date field instead of hard-code \today

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2019-06-20  Joseph Stachelek  <stachel2@msu.edu>
+
+    * inst/rmarkdown/templates/presento/resources/template.tex: Correctly
+    pull date from Rmd rather than hardcode today
+
 2019-03-26  Dirk Eddelbuettel  <edd@debian.org>
 
 	* README.md: Add dependencies badge

--- a/inst/rmarkdown/templates/presento/resources/template.tex
+++ b/inst/rmarkdown/templates/presento/resources/template.tex
@@ -28,7 +28,7 @@ $endif$
   \else
     \usepackage{fontspec}
   \fi
-  % DEdd Commented-out for binb use as it conflicts with presento font scaling  
+  % DEdd Commented-out for binb use as it conflicts with presento font scaling
   %\defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
 $for(fontfamilies)$
   \newfontfamily{$fontfamilies.name$}[$fontfamilies.options$]{$fontfamilies.font$}
@@ -249,7 +249,7 @@ $if(author)$
   $if(address)$ \\\setnote{$address$} $endif$
 }
 $endif$
-\newcommand{\myDetails}{\setnote{\today}}
+\newcommand{\myDetails}{\setnote{$date$}}
 
 %sty file
 %\usepackage{config/presento}


### PR DESCRIPTION
The `presento` template currently hard-codes `\today` rather than reading from the Rmd `date` field.