### PR TITLE
Add `titlegraphic` support to Metropolis

### DIFF
--- a/inst/rmarkdown/templates/metropolis/resources/template.tex
+++ b/inst/rmarkdown/templates/metropolis/resources/template.tex
@@ -303,6 +303,10 @@ $endif$
   $endif$
 }
 
+$if(titlegraphic)$
+  \titlegraphic{\hfill\includegraphics[height=1cm]{$titlegraphic$}}
+$endif$
+
 \begin{document}
 
 % Hide progress bar and footline on titlepage


### PR DESCRIPTION
One of the bazillion useful features of Metropolis mentioned in #1 is the option to add a title graphic. This little pull request enables that with a Pandoc variable. The logo is flushed to the right, just like in the [original Metropolis demo](https://github.com/matze/mtheme/blob/671aa01b9955694e7fb9e36b157552ff904d260a/demo/demo.tex#L20) but I made it a bit smaller, otherwise a longer title would almost touch the logo.