### PR TITLE
Release 0.0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,14 @@
 
 language: c
 sudo: required
-dist: trusty
+dist: bionic
+
+jobs:
+  include:
+    #- name: r-3.5
+    #  env: R_VERSION="3.5"
+    - name: r-4.0
+      env: R_VERSION="4.0"
 
 before_install:
   - curl -OLs https://eddelbuettel.github.io/r-travis/run.sh && chmod 0755 run.sh

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,8 @@
 
 	* DESCRIPTION (Version, Date): Release 0.0.6
 
+	* .travis.yml: Switch to bionic and R 4.0.0
+
 2020-06-08  Joseph Stachelek  <stachel2@msu.edu>
 
 	* R/binb.R: Update natbib default from 'none' to 'default' to please

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2020-06-10  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version, Date): Release 0.0.6
+
+2020-06-08  Joseph Stachelek  <stachel2@msu.edu>
+
+	* R/binb.R: Update natbib default from 'none' to 'default' to please
+	current rmarkdown package
+
 2020-04-08  Dirk Eddelbuettel  <edd@debian.org>
 
 	* README.md: Add 'last commit' badge

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: binb
 Type: Package
 Title: 'binb' is not 'Beamer'
-Version: 0.0.5
-Date: 2019-11-02
+Version: 0.0.6
+Date: 2020-06-10
 Author: Dirk Eddelbuettel, Ista Zahn and Rob Hyndman
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: A collection of 'LaTeX' styles using 'Beamer' customization for
@@ -18,4 +18,4 @@ Imports: rmarkdown, knitr
 VignetteBuilder: knitr
 License: GPL (>= 2)
 Encoding: UTF-8
-RoxygenNote: 6.1.1
+RoxygenNote: 6.0.1

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,6 +3,16 @@
 \newcommand{\ghpr}{\href{https://github.com/eddelbuettel/binb/pull/#1}{##1}}
 \newcommand{\ghit}{\href{https://github.com/eddelbuettel/binb/issues/#1}{##1}}
 
+\section{Changes in binb version 0.0.6 (2020-06-10)}{
+  \itemize{
+    \item Support for YAML option \code{titlegraphic} was added in
+    Metropolis (Andras Scraka in \ghpr{23}).
+    \item The README.md file received another badge (Dirk).
+    \item The \code{natbib} default value was updated to accomodate
+    \pkg{rmarkdown} (Joseph Stachelek in \ghpr{26}).
+  }
+}
+
 \section{Changes in binb version 0.0.5 (2019-11-02)}{
   \itemize{
     \item The Monash theme was updated with new titlepage and font

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -10,6 +10,7 @@
     \item The README.md file received another badge (Dirk).
     \item The \code{natbib} default value was updated to accomodate
     \pkg{rmarkdown} (Joseph Stachelek in \ghpr{26}).
+    \item Travis now uses R 4.0.0 and 'bionic' (Dirk).
   }
 }
 

--- a/man/metropolis.Rd
+++ b/man/metropolis.Rd
@@ -8,36 +8,32 @@
 \title{Binb is not Beamer - PDF Presentation Themes}
 \usage{
 metropolis(toc = FALSE, slide_level = 2, incremental = FALSE,
-  fig_width = 10, fig_height = 7, fig_crop = TRUE,
-  fig_caption = TRUE, dev = "pdf", df_print = "default",
-  fonttheme = "default", highlight = "tango", keep_tex = FALSE,
-  latex_engine = "xelatex", citation_package = c("none", "natbib",
-  "biblatex"), includes = NULL, md_extensions = NULL,
-  pandoc_args = NULL)
+  fig_width = 10, fig_height = 7, fig_crop = TRUE, fig_caption = TRUE,
+  dev = "pdf", df_print = "default", fonttheme = "default",
+  highlight = "tango", keep_tex = FALSE, latex_engine = "xelatex",
+  citation_package = c("default", "natbib", "biblatex"), includes = NULL,
+  md_extensions = NULL, pandoc_args = NULL)
 
-iqss(toc = FALSE, slide_level = 3, incremental = FALSE,
-  fig_width = 10, fig_height = 7, fig_crop = TRUE,
-  fig_caption = TRUE, dev = "pdf", df_print = "default",
-  fonttheme = "default", highlight = "haddock", keep_tex = FALSE,
-  latex_engine = "xelatex", citation_package = c("none", "natbib",
-  "biblatex"), includes = NULL, md_extensions = NULL,
-  pandoc_args = NULL)
+iqss(toc = FALSE, slide_level = 3, incremental = FALSE, fig_width = 10,
+  fig_height = 7, fig_crop = TRUE, fig_caption = TRUE, dev = "pdf",
+  df_print = "default", fonttheme = "default", highlight = "haddock",
+  keep_tex = FALSE, latex_engine = "xelatex",
+  citation_package = c("default", "natbib", "biblatex"), includes = NULL,
+  md_extensions = NULL, pandoc_args = NULL)
 
-monash(toc = FALSE, slide_level = 2, incremental = FALSE,
-  fig_width = 8, fig_height = 5, fig_crop = TRUE,
-  fig_caption = TRUE, dev = "pdf", df_print = "default",
-  fonttheme = "default", colortheme = "monashwhite",
+monash(toc = FALSE, slide_level = 2, incremental = FALSE, fig_width = 8,
+  fig_height = 5, fig_crop = TRUE, fig_caption = TRUE, dev = "pdf",
+  df_print = "default", fonttheme = "default", colortheme = "monashwhite",
   highlight = "tango", keep_tex = FALSE, latex_engine = "pdflatex",
-  citation_package = c("none", "natbib", "biblatex"), includes = NULL,
+  citation_package = c("default", "natbib", "biblatex"), includes = NULL,
   md_extensions = NULL, pandoc_args = NULL)
 
 presento(toc = FALSE, slide_level = 2, incremental = FALSE,
-  fig_width = 10, fig_height = 7, fig_crop = TRUE,
-  fig_caption = TRUE, dev = "pdf", df_print = "default",
-  fonttheme = "default", highlight = "haddock", keep_tex = FALSE,
-  latex_engine = "xelatex", citation_package = c("none", "natbib",
-  "biblatex"), includes = NULL, md_extensions = NULL,
-  pandoc_args = NULL)
+  fig_width = 10, fig_height = 7, fig_crop = TRUE, fig_caption = TRUE,
+  dev = "pdf", df_print = "default", fonttheme = "default",
+  highlight = "haddock", keep_tex = FALSE, latex_engine = "xelatex",
+  citation_package = c("default", "natbib", "biblatex"), includes = NULL,
+  md_extensions = NULL, pandoc_args = NULL)
 }
 \arguments{
 \item{toc}{A logical variable defaulting to \code{FALSE}.}
@@ -68,7 +64,7 @@ presento(toc = FALSE, slide_level = 2, incremental = FALSE,
 \item{latex_engine}{A character variable defaulting to \dQuote{xelatex}.}
 
 \item{citation_package}{An optional character variable with possible value
-\dQuote{none}, \dQuote{natbib} (the default), or \dQuote{biblatex}.}
+\dQuote{default}, \dQuote{natbib} (the default), or \dQuote{biblatex}.}
 
 \item{includes}{An optional character variable defaulting to \code{NULL}.}
 


### PR DESCRIPTION
Hi @robjhyndman and @izahn -- quick little PR finalising a minor maintenance release 0.0.6.

We had two external PRs: one to add titlepage support to the Metropolis YAML header, and one to update the default natbib value to silence a nag from rmarkdown.  I made two small cosmetic changes.

Nothing more.  Are you ok with a minor release, or is there a reason to wait for something else or bigger?     Cheers,  D.