### PR TITLE
Add a new counter for captionless tables (closes #32)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2026-04-29  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/rmarkdown/templates/metropolis/resources/template.tex: Add a
+	new counter variable as needed by newer pandoc
+
+2026-04-06  Rob J Hyndman  <robjhyndman@gmail.com>
+
+	* DESCRIPTION: Correct typo in two of the three 'aut' tags
+
 2025-11-27  Dirk Eddelbuettel  <edd@debian.org>
 
 	* .github/workflows/ci.yaml: Switch to actions/checkout@v6

--- a/inst/rmarkdown/templates/iqss/resources/template.tex
+++ b/inst/rmarkdown/templates/iqss/resources/template.tex
@@ -169,6 +169,8 @@ $if(tables)$
   \makeatletter
   \def\fnum@table{\tablename~\thetable}
   \makeatother
+  % Borrowed from beamer_presentation for newer pandoc per issue #32
+  \newcounter{none}  % for unnumbered tables
 $endif$
 
 $if(graphics)$

--- a/inst/rmarkdown/templates/metropolis/resources/template.tex
+++ b/inst/rmarkdown/templates/metropolis/resources/template.tex
@@ -168,6 +168,8 @@ $if(tables)$
   \makeatletter
   \def\fnum@table{\tablename~\thetable}
   \makeatother
+  % Borrowed from beamer_presentation for newer pandoc per issue #32
+  \newcounter{none}  % for unnumbered tables
 $endif$
 
 $if(graphics)$

--- a/inst/rmarkdown/templates/monash/resources/template.tex
+++ b/inst/rmarkdown/templates/monash/resources/template.tex
@@ -184,6 +184,8 @@ $if(tables)$
   \makeatletter
   \def\fnum@table{\tablename~\thetable}
   \makeatother
+  % Borrowed from beamer_presentation for newer pandoc per issue #32
+  \newcounter{none}  % for unnumbered tables
 $endif$
 
 $if(graphics)$

--- a/inst/rmarkdown/templates/presento/resources/template.tex
+++ b/inst/rmarkdown/templates/presento/resources/template.tex
@@ -132,7 +132,7 @@ $if(tables)$
 % Borrowed from beamer_presentation for newer pandoc per issue #32
 \newcounter{none}  % for unnumbered tables
 % Fix footnotes in tables (requires footnote package)
-\IfFileExists{footnote.sty}{\usepackage{footnote}\makesavenoteenv{long table}}{}
+%\IfFileExists{footnote.sty}{\usepackage{footnote}\makesavenoteenv{long table}}{}
 $endif$
 $if(graphics)$
 \usepackage{graphicx,grffile}

--- a/inst/rmarkdown/templates/presento/resources/template.tex
+++ b/inst/rmarkdown/templates/presento/resources/template.tex
@@ -129,6 +129,8 @@ $highlighting-macros$
 $endif$
 $if(tables)$
 \usepackage{longtable,booktabs}
+% Borrowed from beamer_presentation for newer pandoc per issue #32
+\newcounter{none}  % for unnumbered tables
 % Fix footnotes in tables (requires footnote package)
 \IfFileExists{footnote.sty}{\usepackage{footnote}\makesavenoteenv{long table}}{}
 $endif$
@@ -267,6 +269,8 @@ $endif$
 
 
 %% presento end
+
+\providecommand{\pandocbounded}[1]{#1}
 
 \begin{document}
 %% DEdd Commented-out for presento

--- a/inst/rmarkdown/templates/presento/resources/template.tex
+++ b/inst/rmarkdown/templates/presento/resources/template.tex
@@ -129,6 +129,8 @@ $highlighting-macros$
 $endif$
 $if(tables)$
 \usepackage{longtable,booktabs}
+% Borrowed from beamer_presentation for newer pandoc per issue #32
+\newcounter{none}  % for unnumbered tables
 % Fix footnotes in tables (requires footnote package)
 \IfFileExists{footnote.sty}{\usepackage{footnote}\makesavenoteenv{long table}}{}
 $endif$

--- a/inst/rmarkdown/templates/presento/resources/template.tex
+++ b/inst/rmarkdown/templates/presento/resources/template.tex
@@ -129,8 +129,6 @@ $highlighting-macros$
 $endif$
 $if(tables)$
 \usepackage{longtable,booktabs}
-% Borrowed from beamer_presentation for newer pandoc per issue #32
-\newcounter{none}  % for unnumbered tables
 % Fix footnotes in tables (requires footnote package)
 \IfFileExists{footnote.sty}{\usepackage{footnote}\makesavenoteenv{long table}}{}
 $endif$


### PR DESCRIPTION
Issue #32 details nicely how newer / newest `pandoc` stumbles with Metropolis over captionless tables unless a new counter is present, so we add the counter as a one-liner in the tex template.